### PR TITLE
Dev 1.1.6

### DIFF
--- a/docs/release/pr-1.1.6-cn.md
+++ b/docs/release/pr-1.1.6-cn.md
@@ -1,0 +1,59 @@
+# Pull Request: dev-1.1.6 → master
+
+[English](pr-1.1.6.md)
+
+## 概述 / Overview
+
+本 PR 将 `dev-1.1.6` 分支合并至 `master`，包含流程执行与缓存优化、上下文传递机制修复、异步线程池参数传递与清理、以及 1.1.6 正式版发布配置等多项增强。
+
+---
+
+## ✨ 主要变更 / Key Changes
+
+### 🔄 流程引擎 (Flow Engine)
+
+- **执行与缓存**：优化流程执行与结果缓存机制
+- **运行控制**：支持停止流程实例
+- **Engine 重构**：`FlowEngine` 重构，并发与等待逻辑优化
+- **循环结构**：循环条件由 `BiFunction` 调整为 `Function`，配合 `ContextBus.get()` 使用
+- **节点行为**：优化节点执行超时与空节点 ID 的返回结构
+
+### ⚡ 异步与线程池 (Async & Thread Pool)
+
+- **参数传递**：优化线程池中异步任务执行时的参数传递与清理逻辑
+- **任务装饰**：`TheadHelper.getDecoratorAsync` 装饰线程池任务，支持 ThreadLocal 传播
+- **Shutdown hook**：简化线程池关闭钩子实现
+- **ThreadLocalBase**：新增抽象类，支持设置值后通过 `initExtra` 执行额外初始化
+
+### 📋 上下文 (Context)
+
+- **复制与传递**：优化上下文复制与传递机制（Notify 相关 BUG 修复）
+
+### 📚 文档与构建 (Documentation & Build)
+
+- **README**：`README.md`、`README_CN.md` 版本号与 Maven/Gradle 依赖示例更新
+- **pom.xml**：新增 `<name>` 元素，配置说明完善
+- **发布配置**：切换至阿里云 Maven 仓库，去除 SNAPSHOT，版本定为 **1.1.6**，清理 `distributionManagement` 冗余配置
+
+---
+
+## 🧪 测试 (Testing)
+
+- `mvn -q test` 单元测试通过
+- 建议运行现有流程示例做冒烟验证
+
+---
+
+## 📦 版本 (Version)
+
+- 发布版本：**1.1.6**
+- Java 8+，Maven 3.x
+
+---
+
+## ✅ 检查清单 (Checklist)
+
+- [ ] CI（单元测试 / 构建）在 `dev-1.1.6` 上通过
+- [ ] 版本号确认为 **1.1.6**（非 SNAPSHOT）
+- [ ] 发布到 Maven Central / 私服所需的 `pom`、签名、账号等已与当前策略一致
+- [ ] 合并后打 Tag：`v1.1.6`

--- a/docs/release/pr-1.1.6.md
+++ b/docs/release/pr-1.1.6.md
@@ -1,0 +1,59 @@
+# Pull Request: dev-1.1.6 → master
+
+[中文](pr-1.1.6-cn.md)
+
+## Overview
+
+This PR merges branch `dev-1.1.6` into `master`, including flow execution and result cache improvements, context replication/delivery fixes, async thread-pool parameter lifecycle improvements, and the **1.1.6** stable release configuration.
+
+---
+
+## ✨ Key Changes
+
+### 🔄 Flow Engine
+
+- **Execution & cache:** Optimized process execution and result caching
+- **Runtime control:** Added support for stopping flow instances
+- **Engine refactor:** `FlowEngine` refactor with concurrency and waiting logic improvements
+- **Loop API:** Loop condition changed from `BiFunction` to `Function`, used with `ContextBus.get()`
+- **Nodes:** Improved return structure for node execution timeout and empty node IDs
+
+### ⚡ Async & Thread Pool
+
+- **Parameter passing:** Optimized parameter passing and cleanup for async tasks on thread pools
+- **Task decoration:** `TheadHelper.getDecoratorAsync` decorates thread-pool tasks with ThreadLocal propagation
+- **Shutdown hook:** Simplified thread-pool shutdown hook implementation
+- **ThreadLocalBase:** New abstract class with `initExtra` for post-value-set initialization
+
+### 📋 Context
+
+- **Replication & delivery:** Improved context replication and propagation (Notify-related bug fix)
+
+### 📚 Documentation & Build
+
+- **README:** Updated `README.md` and `README_CN.md` version and Maven/Gradle dependency examples
+- **pom.xml:** Added `<name>` element, config notes updated
+- **Release config:** Switched to Aliyun Maven repository, removed SNAPSHOT, set version to **1.1.6**, cleaned `distributionManagement` and redundant repo blocks
+
+---
+
+## 🧪 Testing
+
+- Unit tests pass (`mvn -q test`)
+- Suggested smoke: run existing flow examples
+
+---
+
+## 📦 Version
+
+- **1.1.6**
+- Java 8+, Maven 3.x
+
+---
+
+## ✅ Checklist
+
+- [ ] CI (tests / build) passes on `dev-1.1.6`
+- [ ] Version is **1.1.6** (not SNAPSHOT)
+- [ ] Maven Central / private registry requirements (signing, credentials) match current strategy
+- [ ] Tag after merge: `v1.1.6`

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.flower-trees</groupId>
     <artifactId>salt-function-flow</artifactId>
     <name>salt-function-flow</name>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6</version>
 
     <licenses>
         <license>
@@ -171,24 +171,4 @@
             </plugin>
         </plugins>
     </build>
-    <distributionManagement>
-        <repository>
-            <id>2522358-release-cZBeyq</id>
-            <url>https://packages.aliyun.com/67c66d52323741934b797d95/maven/2522358-release-czbeyq</url>
-        </repository>
-        <snapshotRepository>
-            <id>2522358-snapshot-h7sd5Z</id>
-            <url>https://packages.aliyun.com/67c66d52323741934b797d95/maven/2522358-snapshot-h7sd5z</url>
-        </snapshotRepository>
-    </distributionManagement>
-    <!--<distributionManagement>
-        <repository>
-            <id>repo-prod-release</id>
-            <url>https://packages.aliyun.com/67f74065fb34110a021fa8eb/maven/repo-prod-release</url>
-        </repository>
-        <snapshotRepository>
-            <id>repo-test-snapshot</id>
-            <url>https://packages.aliyun.com/67f74065fb34110a021fa8eb/maven/repo-test-snapshot</url>
-        </snapshotRepository>
-    </distributionManagement>-->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -171,4 +171,24 @@
             </plugin>
         </plugins>
     </build>
+    <distributionManagement>
+        <repository>
+            <id>2522358-release-cZBeyq</id>
+            <url>https://packages.aliyun.com/67c66d52323741934b797d95/maven/2522358-release-czbeyq</url>
+        </repository>
+        <snapshotRepository>
+            <id>2522358-snapshot-h7sd5Z</id>
+            <url>https://packages.aliyun.com/67c66d52323741934b797d95/maven/2522358-snapshot-h7sd5z</url>
+        </snapshotRepository>
+    </distributionManagement>
+    <!--<distributionManagement>
+        <repository>
+            <id>repo-prod-release</id>
+            <url>https://packages.aliyun.com/67f74065fb34110a021fa8eb/maven/repo-prod-release</url>
+        </repository>
+        <snapshotRepository>
+            <id>repo-test-snapshot</id>
+            <url>https://packages.aliyun.com/67f74065fb34110a021fa8eb/maven/repo-test-snapshot</url>
+        </snapshotRepository>
+    </distributionManagement>-->
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.github.flower-trees</groupId>
     <artifactId>salt-function-flow</artifactId>
     <name>salt-function-flow</name>
-    <version>1.1.5</version>
+    <version>1.1.6-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/org/salt/function/flow/FlowInstance.java
+++ b/src/main/java/org/salt/function/flow/FlowInstance.java
@@ -76,6 +76,7 @@ public class FlowInstance {
     protected <R> R execute() {
         if (!CollectionUtils.isEmpty(nodeList)) {
             ContextBus contextBus = (ContextBus) ContextBus.get();
+            contextBus.setFlowResult(null);
             for (FlowNode<?,?> flowNode : nodeList) {
                 flowNodeManager.execute(flowNode);
                 if (contextBus.isRollbackProcess()) {
@@ -88,7 +89,11 @@ public class FlowInstance {
                     break;
                 }
             }
-            return contextBus.getFlowResult();
+            R result = contextBus.getFlowResult();
+            if (result != null) {
+                contextBus.putResult(this.getFlowId(), result);
+            }
+            return result;
         }
         throw new RuntimeException("processInstance node list is empty.");
     }

--- a/src/main/java/org/salt/function/flow/context/ContextBus.java
+++ b/src/main/java/org/salt/function/flow/context/ContextBus.java
@@ -186,8 +186,8 @@ public class ContextBus implements IContextBus {
         return TheadHelper.getThreadLocal(LAST_RESULT_KEY);
     }
 
-    public void copy() {
-        ContextBus contextBus = ContextBus.builder()
+    public ContextBus copy() {
+        return ContextBus.builder()
                 .id("context-bus-" + UUID.randomUUID().toString().replaceAll("-", ""))
                 .param(param)
                 .conditionMap(new ConcurrentHashMap<>(conditionMap))
@@ -197,7 +197,6 @@ public class ContextBus implements IContextBus {
                 .runtimeId(runtimeId)
                 .rollbackList(new LinkedList<>())
                 .build();
-        TheadHelper.putThreadLocal(IContextBus.class.getName(), contextBus);
     }
 
     public static ContextBus create(Object param) {

--- a/src/main/java/org/salt/function/flow/node/structure/internal/FlowNodeNotify.java
+++ b/src/main/java/org/salt/function/flow/node/structure/internal/FlowNodeNotify.java
@@ -18,6 +18,7 @@ import org.salt.function.flow.Info;
 import org.salt.function.flow.context.ContextBus;
 import org.salt.function.flow.context.IContextBus;
 import org.salt.function.flow.node.structure.FlowNodeStructure;
+import org.salt.function.flow.thread.TheadHelper;
 
 import java.util.List;
 
@@ -27,9 +28,10 @@ public class FlowNodeNotify extends FlowNodeStructure<Void> {
     public Void doProcessGateway(List<Info> infoList) {
         IContextBus iContextBus = getContextBus();
         for (Info info : infoList) {
+            ContextBus contextBus = ((ContextBus) iContextBus).copy();
             theadHelper.submit(() -> {
                 try {
-                    ((ContextBus) iContextBus).copy();
+                    TheadHelper.putThreadLocal(IContextBus.class.getName(), contextBus);
                     execute(info);
                 } catch (Exception e) {
                     ((ContextBus) iContextBus).putException(info.getIdOrAlias(), e);

--- a/src/main/java/org/salt/function/flow/thread/TheadHelper.java
+++ b/src/main/java/org/salt/function/flow/thread/TheadHelper.java
@@ -17,12 +17,12 @@ package org.salt.function.flow.thread;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.salt.function.flow.util.FlowUtil;
 
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Data
@@ -77,8 +77,9 @@ public class TheadHelper {
     }
 
     public static Runnable getDecoratorAsync(Runnable runnable) {
+        log.debug("process getDecoratorAsync runnable...");
         final Map<String, Object> map = new HashMap<>(getThreadLocal());
-        final List<?> results = threadLocalUsers.stream().map(ThreadLocal::get).collect(Collectors.toList());
+        final List<?> results = threadLocalUsers.stream().map(t -> new HashMap<>((Map<?, ?>) t.get())).toList();
         return () -> {
             threadLocal.set(map);
             for (int i = 0; i < threadLocalUsers.size(); i++) {
@@ -88,6 +89,7 @@ public class TheadHelper {
                 if (threadLocalUser instanceof ThreadLocalBase) {
                     ((ThreadLocalBase<?>)threadLocalUser).initExtra();
                 }
+                log.debug("process getDecoratorAsync runnable addThreadLocal param loop. key:{}, value:{}", threadLocalUser.getClass().getName(), FlowUtil.toJson(threadLocalUser.get()));
             }
             try {
                 runnable.run();
@@ -96,13 +98,15 @@ public class TheadHelper {
                     threadLocalUser.remove();
                 }
                 threadLocal.remove();
+                log.debug("process getDecoratorAsync runnable remove...");
             }
         };
     }
 
     public static <T> Callable<T> getDecoratorAsync(Callable<T> callable) {
+        log.debug("process getDecoratorAsync callable...");
         final Map<String, Object> map = new HashMap<>(getThreadLocal());
-        final List<?> results = threadLocalUsers.stream().map(ThreadLocal::get).collect(Collectors.toList());
+        final List<?> results = threadLocalUsers.stream().map(t -> new HashMap<>((Map<?, ?>) t.get())).toList();
         return () -> {
             threadLocal.set(map);
             for (int i = 0; i < threadLocalUsers.size(); i++) {
@@ -112,6 +116,7 @@ public class TheadHelper {
                 if (threadLocalUser instanceof ThreadLocalBase) {
                     ((ThreadLocalBase<?>)threadLocalUser).initExtra();
                 }
+                log.debug("process getDecoratorAsync callable addThreadLocal param loop. key:{}, value:{}", threadLocalUser.getClass().getName(), FlowUtil.toJson(threadLocalUser.get()));
             }
             try {
                 return callable.call();
@@ -120,6 +125,7 @@ public class TheadHelper {
                     threadLocalUser.remove();
                 }
                 threadLocal.remove();
+                log.debug("process getDecoratorAsync callable remove...");
             }
         };
     }

--- a/src/main/java/org/salt/function/flow/util/FlowUtil.java
+++ b/src/main/java/org/salt/function/flow/util/FlowUtil.java
@@ -22,7 +22,6 @@ import org.apache.commons.beanutils.BeanMap;
 import org.apache.commons.lang.StringUtils;
 import org.salt.function.flow.Info;
 import org.salt.function.flow.context.ContextBus;
-import org.salt.function.flow.context.IContextBus;
 import org.springframework.aop.framework.AdvisedSupport;
 import org.springframework.aop.framework.AopProxy;
 


### PR DESCRIPTION
# Pull Request: dev-1.1.6 → master

[中文](pr-1.1.6-cn.md)

## Overview

This PR merges branch `dev-1.1.6` into `master`, including flow execution and result cache improvements, context replication/delivery fixes, async thread-pool parameter lifecycle improvements, and the **1.1.6** stable release configuration.

---

## ✨ Key Changes

### 🔄 Flow Engine

- **Execution & cache:** Optimized process execution and result caching
- **Runtime control:** Added support for stopping flow instances
- **Engine refactor:** `FlowEngine` refactor with concurrency and waiting logic improvements
- **Loop API:** Loop condition changed from `BiFunction` to `Function`, used with `ContextBus.get()`
- **Nodes:** Improved return structure for node execution timeout and empty node IDs

### ⚡ Async & Thread Pool

- **Parameter passing:** Optimized parameter passing and cleanup for async tasks on thread pools
- **Task decoration:** `TheadHelper.getDecoratorAsync` decorates thread-pool tasks with ThreadLocal propagation
- **Shutdown hook:** Simplified thread-pool shutdown hook implementation
- **ThreadLocalBase:** New abstract class with `initExtra` for post-value-set initialization

### 📋 Context

- **Replication & delivery:** Improved context replication and propagation (Notify-related bug fix)

### 📚 Documentation & Build

- **README:** Updated `README.md` and `README_CN.md` version and Maven/Gradle dependency examples
- **pom.xml:** Added `<name>` element, config notes updated
- **Release config:** Switched to Aliyun Maven repository, removed SNAPSHOT, set version to **1.1.6**, cleaned `distributionManagement` and redundant repo blocks

---

## 🧪 Testing

- Unit tests pass (`mvn -q test`)
- Suggested smoke: run existing flow examples

---

## 📦 Version

- **1.1.6**
- Java 8+, Maven 3.x

---

## ✅ Checklist

- [ ] CI (tests / build) passes on `dev-1.1.6`
- [ ] Version is **1.1.6** (not SNAPSHOT)
- [ ] Maven Central / private registry requirements (signing, credentials) match current strategy
- [ ] Tag after merge: `v1.1.6`
